### PR TITLE
Add module to handle EC2 profile Role creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,14 @@ module "module-network-linux-web-db" {
 # EC2
 ################################################################################
 
+module "module-ec2-iam" {
+  source = "./modules/module-ec2-iam"
+  env = var.env
+  project = var.project
+  create_ec2_iam = var.create_ec2_iam
+  create_ecr_policy = length(var.ecr_repositories) > 0
+}
+
 module "module-ec2-linux-web" {
   source                      = "./modules/module-ec2-linux-web"
   region                      = var.region
@@ -40,7 +48,7 @@ module "module-ec2-linux-web" {
   ec2name                     = var.ec2name
   size                        = var.size
   root_disk                   = var.root_disk
-  iam_instance_profile        = var.use_cloudwatch_for_logging || var.use_cloudwatch_for_monitoring ? module.module-cloudwatch.cloudwatch_profile_name[0] : null
+  iam_instance_profile        = var.create_ec2_iam ? module.module-ec2-iam.ec2_profile_name[0] : null
   create_prefix_for_resources = var.create_prefix_for_resources
 }
 

--- a/modules/module-cloudwatch/main.tf
+++ b/modules/module-cloudwatch/main.tf
@@ -8,63 +8,6 @@ resource "aws_cloudwatch_log_group" "log-group" {
   retention_in_days = 30
 }
 
-resource "aws_iam_role" "cloudwatch_role" {
-  count = var.use_cloudwatch_for_logging || var.use_cloudwatch_for_monitoring ? 1 : 0
-  name  = var.create_prefix_for_resources ? "${local.prefix}_${var.cloudwatch_log_group}_role" : "${var.cloudwatch_log_group}_role"
-
-  assume_role_policy = <<-EOF
-  {
-    "Version": "2012-10-17",
-    "Statement": [
-      {
-        "Action": [
-          "sts:AssumeRole"
-        ],
-        "Principal": {
-            "Service": "ec2.amazonaws.com"
-        },
-        "Effect": "Allow",
-        "Sid": ""
-      }
-    ]
-  }
-  EOF
-}
-
-resource "aws_iam_instance_profile" "cloudwatch_profile" {
-  count = var.use_cloudwatch_for_logging || var.use_cloudwatch_for_monitoring ? 1 : 0
-  name  = var.create_prefix_for_resources ? "${local.prefix}_${var.cloudwatch_log_group}_profile" : "${var.cloudwatch_log_group}_profile"
-  role  = aws_iam_role.cloudwatch_role[0].name
-}
-
-resource "aws_iam_role_policy" "cloudwatch_policy" {
-  count = var.use_cloudwatch_for_logging ? 1 : 0
-  name  = var.create_prefix_for_resources ? "${local.prefix}_${var.cloudwatch_log_group}_password-policy-parameterstore" : "${var.cloudwatch_log_group}_password-policy-parameterstore"
-  role  = aws_iam_role.cloudwatch_role[0].id
-
-  policy = <<-EOF
-  {
-    "Version": "2012-10-17",
-    "Statement": [
-      {
-        "Effect": "Allow",
-        "Action": [
-            "cloudwatch:PutMetricData",
-            "ec2:DescribeVolumes",
-            "ec2:DescribeTags",
-            "logs:PutLogEvents",
-            "logs:DescribeLogStreams",
-            "logs:DescribeLogGroups",
-            "logs:CreateLogStream",
-            "logs:CreateLogGroup"
-        ],
-        "Resource": "*"
-      }
-    ]
-  }
-  EOF
-}
-
 resource "aws_cloudwatch_metric_alarm" "ec2_cpu" {
   count                     = var.use_cloudwatch_for_monitoring ? 1 : 0
   alarm_name                = var.create_prefix_for_resources ? "${local.prefix}_${var.cloudwatch_log_group}_cpu_utilization" : "cpu_utilization"

--- a/modules/module-cloudwatch/outputs.tf
+++ b/modules/module-cloudwatch/outputs.tf
@@ -1,3 +1,0 @@
-output "cloudwatch_profile_name" {
-  value = aws_iam_instance_profile.cloudwatch_profile.*.name
-}

--- a/modules/module-ec2-iam/main.tf
+++ b/modules/module-ec2-iam/main.tf
@@ -1,0 +1,87 @@
+
+resource "aws_iam_role" "ec2_iam_role" {
+  count = var.create_ec2_iam ? 1 : 0
+  name  = "${local.prefix}_ec2_role"
+
+  assume_role_policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": [
+          "sts:AssumeRole"
+        ],
+        "Principal": {
+            "Service": "ec2.amazonaws.com"
+        },
+        "Effect": "Allow",
+        "Sid": ""
+      }
+    ]
+  }
+  EOF
+}
+
+resource "aws_iam_instance_profile" "ec2_profile" {
+  count = var.create_ec2_iam ? 1 : 0
+  name  = "${local.prefix}_ec2_profile"
+  role  = aws_iam_role.ec2_iam_role[0].name
+}
+
+resource "aws_iam_role_policy" "ec2_cloudwatch_policy" {
+  count = var.create_ec2_iam && var.create_cloudwatch_policy ? 1 : 0
+  name  = "${local.prefix}_cloudwatch_access_policy"
+  role  = aws_iam_role.ec2_iam_role[0].name
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+            "cloudwatch:PutMetricData",
+            "ec2:DescribeVolumes",
+            "ec2:DescribeTags",
+            "logs:PutLogEvents",
+            "logs:DescribeLogStreams",
+            "logs:DescribeLogGroups",
+            "logs:CreateLogStream",
+            "logs:CreateLogGroup"
+        ],
+        "Resource": "*"
+      }
+    ]
+  }
+  EOF
+}
+
+resource "aws_iam_role_policy" "ec2_ecr_policy" {
+  count = var.create_ec2_iam && var.create_ecr_policy ? 1 : 0
+  name  = "${local.prefix}_ecr_access_policy"
+  role  = aws_iam_role.ec2_iam_role[0].name
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": [
+          "ecr:GetAuthorizationToken",
+          "ecr:ListImages",
+          "ecr:BatchGetImage",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:CompleteLayerUpload",
+          "ecr:GetDownloadUrlForLayer"
+        ],
+        "Effect": "Allow",
+        "Resource": "*"
+      }
+    ]
+  }
+  EOF
+}
+
+locals {
+  prefix = "${var.project}_${var.env}"
+}

--- a/modules/module-ec2-iam/output.tf
+++ b/modules/module-ec2-iam/output.tf
@@ -1,0 +1,3 @@
+output "ec2_profile_name" {
+  value = aws_iam_instance_profile.ec2_profile.*.name
+}

--- a/modules/module-ec2-iam/variables.tf
+++ b/modules/module-ec2-iam/variables.tf
@@ -1,0 +1,23 @@
+variable "env" {
+  description = "the name of the environment we are managing (staging, rc, production)"
+}
+
+variable "project" {
+  description = "the name of the project"
+}
+
+variable "create_ec2_iam" {
+  description = "whether to create ec2 iam role"
+  default = true
+}
+
+variable "create_cloudwatch_policy" {
+  description = "whether to provide access to cloudwatch"
+  default = true
+}
+
+variable "create_ecr_policy" {
+  description = "whether to provide access to ecr"
+  default = true
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -89,6 +89,11 @@ variable "create_machine_script" {
   default     = "create_machine_script.tmpl"
 }
 
+variable "create_ec2_iam" {
+  description = "whether to create an iam profile for the ec2 with cloudwatch and ecr access"
+  default = true
+}
+
 # RDS
 variable "rds-master" {
   description = "the definition of the RDS database"


### PR DESCRIPTION
## Description

Add module to handle iam role creation to be used as ec2 profile which handles cloudwatch and ecr access policies. This used to be done within the `module-cloudwatch` but only handling access policy for that service.